### PR TITLE
fix: support skill validation in spaced paths

### DIFF
--- a/scripts/run-acceptance.cjs
+++ b/scripts/run-acceptance.cjs
@@ -30,6 +30,7 @@ async function main() {
   await runTest('root-help', testRootHelp);
   await runTest('skill-list', testSkillList);
   await runTest('skill-show', testSkillShow);
+  await runTest('validate-skills-space-path', testValidateSkillsSpacePath);
   await runTest('search-tune-help', testSearchTuneHelp);
   await runTest('search-run-requires-scene-help', testSearchRunRequiresSceneHelp);
   await runTest('search-tune-plan', testSearchTunePlan);
@@ -148,6 +149,27 @@ async function testSkillShow() {
   assert.equal(payload.name, 'vs-item-onboarding');
   assert.match(payload.description, /item-level onboarding/i);
   return `${command.prefix} skill show --name vs-item-onboarding --json`;
+}
+
+async function testValidateSkillsSpacePath() {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'viking acceptance skills '));
+  const copiedRoot = path.join(workspace, 'repo with spaces');
+  try {
+    fs.mkdirSync(path.join(copiedRoot, 'scripts'), { recursive: true });
+    fs.mkdirSync(path.join(copiedRoot, 'src'), { recursive: true });
+    fs.copyFileSync(path.join(root, 'scripts', 'validate-skills.mjs'), path.join(copiedRoot, 'scripts', 'validate-skills.mjs'));
+    fs.cpSync(path.join(root, 'skills'), path.join(copiedRoot, 'skills'), { recursive: true });
+    fs.cpSync(path.join(root, 'src', 'commands'), path.join(copiedRoot, 'src', 'commands'), { recursive: true });
+
+    const { stdout } = await execFileAsync('node', [path.join(copiedRoot, 'scripts', 'validate-skills.mjs')], {
+      cwd: copiedRoot,
+      maxBuffer: 16 * 1024 * 1024
+    });
+    assert.match(stdout, /validated \d+ skill\(s\)/);
+    return `node "${path.join(copiedRoot, 'scripts', 'validate-skills.mjs')}"`;
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
 }
 
 async function testDatasetListHelp() {

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -5,13 +5,15 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const REQUIRED_HEADINGS = ['## When to Use', '## Preconditions', '## Commands', '## Workflow', '## Constraints'];
 const ALLOWED_CATEGORIES = new Set(['shared', 'app', 'data', 'search', 'recommend', 'chat', 'openapi', 'workflow']);
 const ALLOWED_APPLIES_TO = new Set(['codex', 'agents', 'external-agent']);
 const CLI_REQUIREMENT_PATTERN = /^>=\d+\.\d+\.\d+$/;
 
-const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
 const skillsRoot = path.resolve(process.argv[2] || path.join(repoRoot, 'skills'));
 const availableCommands = listAvailableVikingCommands(path.join(repoRoot, 'src', 'commands'));
 


### PR DESCRIPTION
This PR fixes `scripts/validate-skills.mjs` when the repository path contains spaces.

Previously, the script derived the repository root from `new URL(import.meta.url).pathname`, which leaves spaces URL-encoded as `%20`. In a local checkout such as `seaech cli`, this made `npm run validate:skills` look for a non-existent `seaech%20cli/skills` directory.

Changes:
- Use `fileURLToPath(import.meta.url)` to resolve the script directory safely.
- Add an acceptance regression that copies the minimal validation fixture into a path with spaces and runs `validate-skills.mjs` there.

Validation:
- `npm run validate:skills`
- `npm run build`
- `npm run test:acceptance:dist`