### PR TITLE
feat: add data delete command

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -120,6 +120,8 @@ SearchCLI is an interactive AI search command-line tool. Below is the list of cu
     *   Parameters: `[service flags]`
 *   `vs data import --dataset-id <id> --fields @items.json`
     *   Parameters: `[service flags]`
+*   `vs data delete --dataset-id <id> --id <item-id>`
+    *   Parameters: `[service flags]`
 
 ### `search` - Search Runtime and Scenes
 *   `vs search run --application-id <id> --scene-id <id> --query <text>`

--- a/scripts/run-acceptance.cjs
+++ b/scripts/run-acceptance.cjs
@@ -44,6 +44,7 @@ async function main() {
   await runTest('search-tune-run-help', testSearchTuneRunHelp);
   await runTest('app-list-help', testAppListHelp);
   await runTest('dataset-list-help', testDatasetListHelp);
+  await runTest('data-delete-mock', testDataDeleteMock);
   await runTest('config-summary-help', testConfigSummaryHelp);
   await runTest('item-profile', testItemProfile);
   await runTest('item-plan', testItemPlan);
@@ -184,6 +185,48 @@ async function testAppListHelp() {
   const { stdout } = await runCli(['app', '--help']);
   assert.match(stdout, /app list \[--name <text> --dataset-id <id> --industry <type> --state <state> --full\]/i);
   return `${command.prefix} app --help`;
+}
+
+async function testDataDeleteMock() {
+  const serverState = {
+    requests: []
+  };
+  const server = await startDataDeleteMockServer(serverState);
+  try {
+    const dataHelp = await runCli(['data', '--help']);
+    assert.match(dataHelp.stdout, /data delete --dataset-id <id> --id <item-id>/i);
+
+    const { stdout } = await runCli([
+      'data',
+      'delete',
+      '--dataset-id',
+      'ds-1',
+      '--id',
+      'item-1',
+      '--ak',
+      'ak',
+      '--sk',
+      'sk',
+      '--json'
+    ], {
+      env: {
+        VIKING_CONTROL_PLANE_BASE_URL: server.baseUrl,
+        VIKING_DATA_PLANE_BASE_URL: server.baseUrl
+      }
+    });
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.result.deleted, true);
+    assert.deepEqual(serverState.requests, [
+      {
+        url: '/api/v1/dataset/ds-1/delete',
+        body: { _ids: ['item-1'] }
+      }
+    ]);
+    return `${command.prefix} data delete --dataset-id ds-1 --id item-1 --json`;
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
 }
 
 async function testSearchTuneHelp() {
@@ -782,6 +825,33 @@ async function startQueryGenerateMockServer(state) {
           sourceItemIds: [`item-${batchIndex}-${index + 1}`]
         }));
         res.end(JSON.stringify({ choices: [{ message: { content: JSON.stringify(queries) } }] }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: `unexpected path: ${req.url}` }));
+    });
+  });
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: callback => server.close(callback)
+  };
+}
+
+async function startDataDeleteMockServer(state) {
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      const parsedBody = body ? JSON.parse(body) : {};
+      res.setHeader('content-type', 'application/json');
+      if (req.url === '/api/v1/dataset/ds-1/delete') {
+        state.requests.push({ url: req.url, body: parsedBody });
+        res.end(JSON.stringify({ ok: true, result: { deleted: true, ids: parsedBody._ids } }));
         return;
       }
       res.statusCode = 404;

--- a/src/app/product-commands.ts
+++ b/src/app/product-commands.ts
@@ -169,7 +169,7 @@ export interface DataGetOptions extends ServiceCommandOptions {
 
 export interface DataDeleteOptions extends ServiceCommandOptions {
   datasetId: string;
-  ids?: string;
+  id?: string;
 }
 
 export interface SearchRunOptions extends ServiceCommandOptions {
@@ -800,6 +800,16 @@ export async function runDataWriteCommand(options: DataWriteOptions): Promise<vo
   await printResult(callRuntime(runtime => runtime.dataWrite(options.datasetId, payload), options));
 }
 
+export async function runDataDeleteCommand(options: DataDeleteOptions): Promise<void> {
+  const payload =
+    (await loadJsonInput(options.data)) ??
+    compactObject({
+      _ids: options.id ? [options.id] : undefined
+    });
+  requireNonEmptyObject(payload, 'Need --data or --id for data delete.');
+  await printResult(callRuntime(runtime => runtime.dataDelete(options.datasetId, payload), options));
+}
+
 export async function runSearchRunCommand(options: SearchRunOptions): Promise<void> {
   const config = resolveServiceConfig(toServiceConfigInput(options));
   const providedPayload = await loadJsonInput(options.data);
@@ -1372,7 +1382,7 @@ export function printProductDomainsHelp(): void {
     'vs app online-config get|update',
     'vs dataset create|get|list|delete|update|ingest',
     'vs dataset schema get|check',
-    'vs data write|import',
+    'vs data write|import|delete',
     'vs search run|scene create|list|get|update|delete',
     'vs recommend run|scene create|list|get|update|delete',
     'vs chat run'
@@ -1423,7 +1433,8 @@ COMMON FLAGS
     data: `${renderUsageBlock(
       [
         'vs data write --dataset-id <id> --fields @fields.json [service flags]',
-        'vs data import --dataset-id <id> --fields @items.json [service flags]'
+        'vs data import --dataset-id <id> --fields @items.json [service flags]',
+        'vs data delete --dataset-id <id> --id <item-id> [service flags]'
       ]
     )}
 
@@ -2394,6 +2405,9 @@ async function runDataCli(argv: string[]): Promise<void> {
       return;
     case 'import':
       await runDataImportShortcutCommand({ ...serviceOptions, datasetId, fields: optionalString(values.fields) });
+      return;
+    case 'delete':
+      await runDataDeleteCommand({ ...serviceOptions, datasetId, id: optionalString(values.id) });
       return;
     default:
       throw new Error(`Unknown data subcommand: ${action}`);

--- a/src/commands/data/delete.ts
+++ b/src/commands/data/delete.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command, Flags } from '@oclif/core';
+import { runDataDeleteCommand } from '../../app/product-commands';
+import { serviceFlags } from '../../command-support/service-flags';
+
+export default class DataDelete extends Command {
+  static override description = 'Delete one item/event from a dataset.';
+
+  static override examples = [
+    '<%= config.bin %> data delete --dataset-id 123 --id item-1',
+    '<%= config.bin %> data delete --dataset-id 123 --data @payload.json'
+  ];
+
+  static override flags = {
+    ...serviceFlags,
+    'dataset-id': Flags.string({ required: true }),
+    id: Flags.string({
+      description: 'Item/event ID to delete.'
+    })
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(DataDelete);
+    await runDataDeleteCommand({
+      baseUrl: flags['base-url'],
+      controlPlaneBaseUrl: flags['control-plane-base-url'],
+      dataPlaneBaseUrl: flags['data-plane-base-url'],
+      accessKeyId: flags.ak,
+      secretKey: flags.sk,
+      region: flags.region,
+      timeoutMs: flags['timeout-ms'],
+      data: flags.data,
+      datasetId: flags['dataset-id'],
+      id: flags.id
+    });
+  }
+}


### PR DESCRIPTION

## Summary

Add a minimal `vs data delete` command for deleting a single item/event from an existing dataset.

```bash
vs data delete --dataset-id <id> --id <item-id>
```

By default the command sends the backend-required payload shape:

```json
{ "_ids": ["<item-id>"] }
```

It also keeps `--data @payload.json` support for advanced/raw backend payloads.

## Changes

- Add `src/commands/data/delete.ts`.
- Add `runDataDeleteCommand` and wire `data delete` into the standalone dispatcher.
- Update CLI help and `docs/COMMANDS.md`.
- Add mock acceptance coverage for the delete runtime request.

## Test Plan

```bash
npm run validate:skills
npm run build
```

`data-delete-mock` passes in the dist acceptance suite.

Full `npm run test:acceptance:dist` was run; the delete acceptance case passed, while unrelated existing search-tune mock cases failed because localhost `--base-url` now requires split endpoint configuration.

## Real Service Verification

Verified against a temporary real Viking AI Search item dataset.

- Created temporary dataset `122903180` (`codex-delete-e2e-20260529032133`).
- Wrote test items with `vs data write`.
- Confirmed the initial `{ "_id": "..." }` payload failed with `MissingParameter: ids`.
- Verified the backend accepts `{ "_ids": ["<item-id>"] }`.
- Updated `vs data delete --id` to send `{ "_ids": ["<item-id>"] }`.
- Verified `vs data delete --dataset-id 122903180 --id <item-id> --json` succeeds.
- Verified the deleted item eventually returns `found=false` via `get_item` polling.
- Deleted the temporary dataset and confirmed `GetDataset` returns `ResourceNotFound.Dataset`.

## Notes

This PR intentionally supports single-item delete only. It does not add batch delete, dry-run, sync behavior, endpoint plumbing, or confirmation prompts.