### PR TITLE
I18n/turkish readme

### DIFF
--- a/README.de_DE.md
+++ b/README.de_DE.md
@@ -4,7 +4,7 @@
 
 # SearchCLI
 
-[English](README.md) | [简体中文](README.zh_CN.md) | [日本語](README.ja_JP.md) | Deutsch | [한국어](README.ko_KR.md) | [Français](README.fr_FR.md) | [Русский](README.ru_RU.md) | [Italiano](README.it_IT.md) | [Español](README.es_ES.md) | [Português](README.pt_BR.md)
+[English](README.md) | [简体中文](README.zh_CN.md) | [日本語](README.ja_JP.md) | Deutsch | [한국어](README.ko_KR.md) | [Français](README.fr_FR.md) | [Русский](README.ru_RU.md) | [Italiano](README.it_IT.md) | [Español](README.es_ES.md) | [Português](README.pt_BR.md) | [Türkçe](README.tr_TR.md)
 
 Verbinde stabile, abstimmbare Suche, Empfehlungen und konversationelle Suche mit deinem Agent-System oder Business-System.
 

--- a/README.es_ES.md
+++ b/README.es_ES.md
@@ -4,7 +4,7 @@
 
 # SearchCLI
 
-[English](README.md) | [简体中文](README.zh_CN.md) | [日本語](README.ja_JP.md) | [Deutsch](README.de_DE.md) | [한국어](README.ko_KR.md) | [Français](README.fr_FR.md) | [Русский](README.ru_RU.md) | [Italiano](README.it_IT.md) | Español | [Português](README.pt_BR.md)
+[English](README.md) | [简体中文](README.zh_CN.md) | [日本語](README.ja_JP.md) | [Deutsch](README.de_DE.md) | [한국어](README.ko_KR.md) | [Français](README.fr_FR.md) | [Русский](README.ru_RU.md) | [Italiano](README.it_IT.md) | Español | [Português](README.pt_BR.md) | [Türkçe](README.tr_TR.md)
 
 Conecta búsqueda estable y ajustable, recomendaciones y retrieval conversacional a tu sistema Agent o sistema de negocio.
 

--- a/README.fr_FR.md
+++ b/README.fr_FR.md
@@ -4,7 +4,7 @@
 
 # SearchCLI
 
-[English](README.md) | [简体中文](README.zh_CN.md) | [日本語](README.ja_JP.md) | [Deutsch](README.de_DE.md) | [한국어](README.ko_KR.md) | Français | [Русский](README.ru_RU.md) | [Italiano](README.it_IT.md) | [Español](README.es_ES.md) | [Português](README.pt_BR.md)
+[English](README.md) | [简体中文](README.zh_CN.md) | [日本語](README.ja_JP.md) | [Deutsch](README.de_DE.md) | [한국어](README.ko_KR.md) | Français | [Русский](README.ru_RU.md) | [Italiano](README.it_IT.md) | [Español](README.es_ES.md) | [Português](README.pt_BR.md) | [Türkçe](README.tr_TR.md)
 
 Connectez une recherche stable et ajustable, des recommandations et une recherche conversationnelle à votre système Agent ou à votre système métier.
 

--- a/README.it_IT.md
+++ b/README.it_IT.md
@@ -4,7 +4,7 @@
 
 # SearchCLI
 
-[English](README.md) | [简体中文](README.zh_CN.md) | [日本語](README.ja_JP.md) | [Deutsch](README.de_DE.md) | [한국어](README.ko_KR.md) | [Français](README.fr_FR.md) | [Русский](README.ru_RU.md) | Italiano | [Español](README.es_ES.md) | [Português](README.pt_BR.md)
+[English](README.md) | [简体中文](README.zh_CN.md) | [日本語](README.ja_JP.md) | [Deutsch](README.de_DE.md) | [한국어](README.ko_KR.md) | [Français](README.fr_FR.md) | [Русский](README.ru_RU.md) | Italiano | [Español](README.es_ES.md) | [Português](README.pt_BR.md) | [Türkçe](README.tr_TR.md)
 
 Collega ricerca stabile e regolabile, raccomandazioni e retrieval conversazionale al tuo sistema Agent o al tuo sistema business.
 

--- a/README.ja_JP.md
+++ b/README.ja_JP.md
@@ -4,7 +4,7 @@
 
 # SearchCLI
 
-[English](README.md) | [简体中文](README.zh_CN.md) | 日本語 | [Deutsch](README.de_DE.md) | [한국어](README.ko_KR.md) | [Français](README.fr_FR.md) | [Русский](README.ru_RU.md) | [Italiano](README.it_IT.md) | [Español](README.es_ES.md) | [Português](README.pt_BR.md)
+[English](README.md) | [简体中文](README.zh_CN.md) | 日本語 | [Deutsch](README.de_DE.md) | [한국어](README.ko_KR.md) | [Français](README.fr_FR.md) | [Русский](README.ru_RU.md) | [Italiano](README.it_IT.md) | [Español](README.es_ES.md) | [Português](README.pt_BR.md) | [Türkçe](README.tr_TR.md)
 
 安定して調整可能な検索、推薦、会話型検索を Agent システムや業務システムに接続します。
 

--- a/README.ko_KR.md
+++ b/README.ko_KR.md
@@ -4,7 +4,7 @@
 
 # SearchCLI
 
-[English](README.md) | [简体中文](README.zh_CN.md) | [日本語](README.ja_JP.md) | [Deutsch](README.de_DE.md) | 한국어 | [Français](README.fr_FR.md) | [Русский](README.ru_RU.md) | [Italiano](README.it_IT.md) | [Español](README.es_ES.md) | [Português](README.pt_BR.md)
+[English](README.md) | [简体中文](README.zh_CN.md) | [日本語](README.ja_JP.md) | [Deutsch](README.de_DE.md) | 한국어 | [Français](README.fr_FR.md) | [Русский](README.ru_RU.md) | [Italiano](README.it_IT.md) | [Español](README.es_ES.md) | [Português](README.pt_BR.md) | [Türkçe](README.tr_TR.md)
 
 안정적이고 조정 가능한 검색, 추천, 대화형 검색 기능을 Agent 시스템 또는 비즈니스 시스템에 연결합니다.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # SearchCLI
 
-English | [简体中文](README.zh_CN.md) | [日本語](README.ja_JP.md) | [Deutsch](README.de_DE.md) | [한국어](README.ko_KR.md) | [Français](README.fr_FR.md) | [Русский](README.ru_RU.md) | [Italiano](README.it_IT.md) | [Español](README.es_ES.md) | [Português](README.pt_BR.md)
+English | [简体中文](README.zh_CN.md) | [日本語](README.ja_JP.md) | [Deutsch](README.de_DE.md) | [한국어](README.ko_KR.md) | [Français](README.fr_FR.md) | [Русский](README.ru_RU.md) | [Italiano](README.it_IT.md) | [Español](README.es_ES.md) | [Português](README.pt_BR.md) | [Türkçe](README.tr_TR.md)
 
 Connect stable, tunable search, recommendation, and conversational retrieval to your agent system or business system.
 

--- a/README.pt_BR.md
+++ b/README.pt_BR.md
@@ -4,7 +4,7 @@
 
 # SearchCLI
 
-[English](README.md) | [简体中文](README.zh_CN.md) | [日本語](README.ja_JP.md) | [Deutsch](README.de_DE.md) | [한국어](README.ko_KR.md) | [Français](README.fr_FR.md) | [Русский](README.ru_RU.md) | [Italiano](README.it_IT.md) | [Español](README.es_ES.md) | Português
+[English](README.md) | [简体中文](README.zh_CN.md) | [日本語](README.ja_JP.md) | [Deutsch](README.de_DE.md) | [한국어](README.ko_KR.md) | [Français](README.fr_FR.md) | [Русский](README.ru_RU.md) | [Italiano](README.it_IT.md) | [Español](README.es_ES.md) | Português | [Türkçe](README.tr_TR.md)
 
 Conecte busca estável e ajustável, recomendações e retrieval conversacional ao seu sistema Agent ou sistema de negócios.
 

--- a/README.ru_RU.md
+++ b/README.ru_RU.md
@@ -4,7 +4,7 @@
 
 # SearchCLI
 
-[English](README.md) | [简体中文](README.zh_CN.md) | [日本語](README.ja_JP.md) | [Deutsch](README.de_DE.md) | [한국어](README.ko_KR.md) | [Français](README.fr_FR.md) | Русский | [Italiano](README.it_IT.md) | [Español](README.es_ES.md) | [Português](README.pt_BR.md)
+[English](README.md) | [简体中文](README.zh_CN.md) | [日本語](README.ja_JP.md) | [Deutsch](README.de_DE.md) | [한국어](README.ko_KR.md) | [Français](README.fr_FR.md) | Русский | [Italiano](README.it_IT.md) | [Español](README.es_ES.md) | [Português](README.pt_BR.md) | [Türkçe](README.tr_TR.md)
 
 Подключайте стабильный, настраиваемый поиск, рекомендации и диалоговый retrieval к вашей Agent-системе или бизнес-системе.
 

--- a/README.tr_TR.md
+++ b/README.tr_TR.md
@@ -1,0 +1,244 @@
+<p align="center">
+  <img src="docs/assets/searchcli-logo.svg" alt="SearchCLI logo" width="560" />
+</p>
+
+# SearchCLI
+
+[English](README.md) | [简体中文](README.zh_CN.md) | [日本語](README.ja_JP.md) | [Deutsch](README.de_DE.md) | [한국어](README.ko_KR.md) | [Français](README.fr_FR.md) | [Русский](README.ru_RU.md) | [Italiano](README.it_IT.md) | [Español](README.es_ES.md) | [Português](README.pt_BR.md) | Türkçe
+
+Kararlı ve ayarlanabilir arama, öneri ve konuşmalı retrieval özelliklerini Agent sisteminize veya iş sisteminize bağlayın.
+
+[Hızlı Başlangıç (geliştiriciler)](#hızlı-başlangıç-geliştiriciler) · [AI Agent kurulumu](#hızlı-başlangıç-ai-agents) · [Tam Agent kılavuzu](docs/agent-quick-start.md) · [Katkıda bulunma](CONTRIBUTING.md) · [Güvenlik](SECURITY.md)
+
+SearchCLI, AI Search on Volcengine için açık CLI'dır.
+
+Agent sisteminiz veya iş sisteminiz kararlı ve ayarlanabilir bilgi dağıtım servislerine ihtiyaç duyuyorsa, SearchCLI production düzeyinde arama, öneri ve konuşmalı retrieval özelliklerini gerçek workflow'lara entegre etmek için pratik bir yol sunar.
+
+SearchCLI ve kurulabilir `Viking skills` ile harici Agents veri onboarding yapabilir, arama ve öneri akışları oluşturup doğrulayabilir, konuşmalı retrieval çalıştırabilir, strateji yapılandırmasını ayarlayabilir, bad cases inceleyebilir ve retrieval kalitesini kararlı, incelenebilir bir şekilde yineleyerek iyileştirebilir.
+
+## SearchCLI nedir
+
+- AI Search on Volcengine için komut satırı entegrasyon yüzeyidir.
+- Harici sistemlerin arama, öneri ve konuşmalı retrieval özelliklerine erişmesi için kararlı bir yoldur.
+- Kurulabilir skills ve otomasyona güvenli komut çıktısı etrafında oluşturulmuş Agent dostu bir workflow katmanıdır.
+- Dry-run, onay kapıları ve write sonrası read doğrulaması içeren incelenebilir bir yürütme modelidir.
+
+## Kimler için
+
+- AI destekli bilgi dağıtımını iş sistemlerine entegre eden geliştiriciler.
+- Kararlı ve yapılandırılabilir arama, öneri ve retrieval workflow'larına ihtiyaç duyan Agent sistemleri geliştiren ekipler.
+- Production kullanımı öncesinde veri onboarding, uygulama yapılandırması ve runtime davranışını incelenebilir şekilde doğrulamak isteyen operasyon, delivery ve çözüm ekipleri.
+
+## Neler sağlar
+
+- Yapılandırılmış iş verileri üzerinde item ve catalog araması.
+- Uygulama sahneleri ve kullanıcı davranışıyla bağlantılı öneri akışları.
+- Uygulama aramasına dayalı konuşmalı retrieval deneyimleri.
+- Verileri onboard eden, uygulamaları yapılandıran ve runtime davranışını açık inceleme adımlarıyla doğrulayan Agent workflow'ları.
+
+## Temel özellikler
+
+- Yapılandırılmış item onboarding için `vs item profile | plan | apply`.
+- Uygulama ve dataset yönetimi için `vs app`, `vs dataset` ve `vs data`.
+- Runtime doğrulama için `vs search run`, `vs recommend run` ve `vs chat run`.
+- Metin benzerliği için ilk sürüm otomatik değerlendirme ve ayarlama amacıyla `vs search tune query-generate | plan | run | report`.
+- Harici Agents'ın aynı workflow'ları kullanabilmesi için kurulabilir `Viking skills`.
+
+## Gereksinimler
+
+- Node.js 20 veya daha yeni
+- `git`
+- AI Search erişimi olan Volcengine AK/SK
+
+## Hızlı Başlangıç (geliştiriciler)
+
+### 1. Kurulum
+
+```bash
+git clone git@github.com:volcengine/SearchCLI.git vs
+cd vs
+bash ./scripts/install.sh
+```
+
+### 2. Kimlik doğrulama
+
+Geçerli shell'de `VIKING_AK` ve `VIKING_SK` zaten ayarlıysa:
+
+```bash
+vs auth import-env
+vs auth status --json
+vs doctor --json
+```
+
+Aksi halde gerçek bir terminalde etkileşimli login çalıştırın:
+
+```bash
+vs auth login
+```
+
+Search tuning sorgu üretimi veya LLM ile ilgililik değerlendirmesi kullanacaksanız, API key'i düz metin yapılandırmaya koymadan OpenAI-compatible LLM API yapılandırın:
+
+```bash
+vs llm login
+vs llm status --json
+vs search tune llm-check --live --json
+```
+
+Geçerli shell'de `VIKING_LLM_BASE_URL`, `VIKING_LLM_API_KEY` ve `VIKING_LLM_MODEL` zaten ayarlıysa bunun yerine `vs llm import-env` kullanabilirsiniz. API key yerel güvenli kimlik bilgisi deposunda saklanır; base URL ve model gizli olmayan yapılandırma olarak saklanır.
+
+### 3. İlk onboarding flow'u çalıştırma
+
+Kullanıcı yeni bir app, bind-time yapılandırma incelemesi ve runtime doğrulama istiyorsa `dataset+app` yolunu kullanın:
+
+```bash
+vs item profile --file ./items.json --pretty
+vs item plan --file ./items.json --goal "Build item search"
+vs item apply --plan-dir ./.viking/item-plans/<plan> --dry-run
+vs item apply --plan-dir ./.viking/item-plans/<plan> --confirm-review --wait-ready --run-trials
+```
+
+Yalnızca dataset provisioning gerekiyorsa `dataset-only` yolunu kullanın, `--skip-app` ile dataset-only plan oluşturun ve dataset create + ingest sonrasında durun:
+
+```bash
+vs item profile --file ./items.json --pretty
+vs item plan --file ./items.json --goal "Build item search" --skip-app
+vs dataset create --data @dataset-create.json
+vs dataset ingest --dataset-id <dataset-id> --fields @<normalized-items-artifact>
+```
+
+Plan `dataset-create.json` ürettiyse bunu tercih edin; böylece dataset oluşturma sırasında `Schema` ve `DataFieldConfig` birlikte gönderilir. Tam bir create payload yoksa veya uygun değilse `--name <dataset-name> --type item --schema @schema.json` biçimi manuel schema-only fallback olarak kalır.
+
+Mevcut bir plandan dataset-only sınırını zorunlu tutmanız gerektiğinde `--skip-app`, `vs item provision` ve `vs item apply` tarafından execution-time guard rail olarak da kabul edilir.
+
+Video dataset gerekiyorsa varsayılan tipe güvenmeyin. Her zaman açıkça `--type video` geçirin:
+
+`dataset+app` için:
+
+```bash
+vs item profile --file ./videos.jsonl --type video --pretty
+vs item plan --file ./videos.jsonl --type video --goal "Build video search"
+vs item apply --plan-dir ./.viking/item-plans/<plan> --dry-run
+vs item apply --plan-dir ./.viking/item-plans/<plan> --confirm-review --wait-ready --run-trials
+```
+
+`dataset-only` için:
+
+```bash
+vs item profile --file ./videos.jsonl --type video --pretty
+vs item plan --file ./videos.jsonl --type video --goal "Build video search" --skip-app
+vs dataset create --data @dataset-create.json
+vs dataset ingest --dataset-id <dataset-id> --fields @<normalized-items-artifact>
+```
+
+Video dataset-only provisioning için `dataset-create.json` tercih edin; böylece istek `DataFieldConfig` içerir. Yalnızca `--schema @schema.json` kullanmak `MissingParameter.DefaultFieldStrategy` hatasıyla başarısız olabilir.
+
+## Hızlı Başlangıç (AI Agents)
+
+Harici bir Agent bu repository üzerinden AI Search çalıştıracaksa:
+
+### 1. SearchCLI kurulumu
+
+```bash
+git clone git@github.com:volcengine/SearchCLI.git vs
+cd vs
+bash ./scripts/install.sh
+```
+
+### 2. Viking skills kurulumu
+
+```bash
+npx skills add "git@github.com:volcengine/SearchCLI.git" -y -g
+```
+
+Varsayılan public skill bundle şunları içerir:
+
+- `vs-shared`
+- `vs-item-onboarding`
+- `vs-search`
+- `vs-search-tuning`
+- `vs-chat`
+- `vs-recommend`
+
+### 3. Kimlik doğrulama
+
+Geçerli shell'de `VIKING_AK` ve `VIKING_SK` zaten ayarlıysa şunu tercih edin:
+
+```bash
+vs auth import-env
+```
+
+Aksi halde:
+
+```bash
+vs auth login
+```
+
+### 4. Doğrulama
+
+```bash
+vs --help
+vs auth status --json
+vs llm status --json
+vs doctor --json
+vs skill list
+```
+
+## Public komut grupları
+
+- `vs auth`
+- `vs llm`
+- `vs doctor`
+- `vs skill`
+- `vs item`
+- `vs app`
+- `vs dataset`
+- `vs data`
+- `vs search`
+- `vs chat`
+- `vs recommend`
+
+## Dokümantasyon
+
+- [Agent Quick Start](docs/agent-quick-start.md)
+- [Contributing](CONTRIBUTING.md)
+- [Security](SECURITY.md)
+
+## Maintainer workflow
+
+Open-source repository'nin kendisini maintain ediyorsanız, yerel skill tooling şudur:
+
+```bash
+vs skill list
+vs skill init viking-demo-skill
+vs skill validate
+vs skill install all
+```
+
+Repository kontrollerini build edip çalıştırın:
+
+```bash
+npm install
+npm run validate:skills
+npm run build
+npm run test:acceptance:dist
+```
+
+## Katkıda bulunma
+
+Daha fazla ayrıntı için [Contributing](CONTRIBUTING.md) sayfasını inceleyin.
+
+Harici contributors, bir pull request kabul edilmeden önce Contributor License Agreement (CLA) tamamlamalıdır.
+
+## Davranış Kuralları
+
+Daha fazla ayrıntı için [Code of Conduct](CODE_OF_CONDUCT.md) sayfasını inceleyin.
+
+## Güvenlik
+
+Bu projede olası bir güvenlik sorunu keşfederseniz veya keşfetmiş olabileceğinizi düşünüyorsanız, Bytedance Security'yi [security center](https://security.bytedance.com/src) veya [vulnerability reporting email](mailto:sec@bytedance.com) üzerinden bilgilendirmenizi rica ederiz.
+
+Lütfen public GitHub issue oluşturmayın.
+
+## Lisans
+
+Bu proje [Apache-2.0 License](LICENSE) altında lisanslanmıştır.

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -4,7 +4,7 @@
 
 # SearchCLI
 
-[English](README.md) | 简体中文 | [日本語](README.ja_JP.md) | [Deutsch](README.de_DE.md) | [한국어](README.ko_KR.md) | [Français](README.fr_FR.md) | [Русский](README.ru_RU.md) | [Italiano](README.it_IT.md) | [Español](README.es_ES.md) | [Português](README.pt_BR.md)
+[English](README.md) | 简体中文 | [日本語](README.ja_JP.md) | [Deutsch](README.de_DE.md) | [한국어](README.ko_KR.md) | [Français](README.fr_FR.md) | [Русский](README.ru_RU.md) | [Italiano](README.it_IT.md) | [Español](README.es_ES.md) | [Português](README.pt_BR.md) | [Türkçe](README.tr_TR.md)
 
 将稳定、可调优的搜索、推荐与对话检索能力接入你的 Agent 系统或业务系统。
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "README.it_IT.md",
     "README.es_ES.md",
     "README.pt_BR.md",
+    "README.tr_TR.md",
     "package.json"
   ],
   "engines": {


### PR DESCRIPTION
## Summary

- Add a Turkish localized README: `README.tr_TR.md`
- Add Turkish README links to the language switchers in English, Chinese, Japanese, German, Korean, French, Russian, Italian, Spanish, and Portuguese READMEs
- Include `README.tr_TR.md` in `package.json` so it is included in npm package files

## Commit Structure

Each modified file is kept in a separate commit, including the `package.json` packaging update.

## Validation

- `git diff --check origin/main..HEAD`
- `node -e "JSON.parse(require('node:fs').readFileSync('package.json','utf8')); console.log('package.json ok')"`
- `npm pack --dry-run --ignore-scripts --json`

The dry-run package file list includes `README.tr_TR.md`.