### PR TITLE
fix(skills): normalize Windows line endings

### DIFF
--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -38,7 +38,7 @@ for (const dirName of skillDirs) {
     continue;
   }
 
-  const content = fs.readFileSync(skillFile, 'utf8');
+  const content = fs.readFileSync(skillFile, 'utf8').replace(/\r\n?/g, '\n');
   const frontmatter = parseFrontmatter(content);
   if (!frontmatter) {
     errors.push(`[${dirName}] SKILL.md must start with YAML frontmatter`);

--- a/src/skills/repo-skills.ts
+++ b/src/skills/repo-skills.ts
@@ -265,11 +265,12 @@ export function validateRepoSkills(root = getRepoSkillsRoot()): RepoSkillValidat
 
   for (const dirName of names) {
     const skillFile = path.join(root, dirName, 'SKILL.md');
-    const content = readRepoSkillFile(root, dirName, 'SKILL.md', embedded);
-    if (content === undefined) {
+    const rawContent = readRepoSkillFile(root, dirName, 'SKILL.md', embedded);
+    if (rawContent === undefined) {
       errors.push(`[${dirName}] missing SKILL.md`);
       continue;
     }
+    const content = rawContent.replace(/\r\n?/g, '\n');
     const frontmatter = parseFrontmatter(content);
     if (!frontmatter) {
       errors.push(`[${dirName}] SKILL.md must start with YAML frontmatter`);


### PR DESCRIPTION
## Summary

- normalize skill Markdown line endings before standalone validation
- normalize runtime skill content before frontmatter and section parsing

This keeps CRLF Windows checkouts equivalent to LF checkouts for validation, listing, and skill metadata extraction.

Fixes #47.

## Validation

- `npm run build`
- `npm run validate:skills`
- focused CRLF copy check: standalone validator reports 13 skills; runtime validator reports 13 skills and 0 errors
- `git diff --check`
