### PR TITLE
fix(build): normalize embedded file line endings

### DIFF
--- a/scripts/generate-embedded-project-template.mjs
+++ b/scripts/generate-embedded-project-template.mjs
@@ -52,7 +52,7 @@ async function readDirectoryFiles(baseDir, currentDir) {
     const relativePath = path.relative(baseDir, fullPath).split(path.sep).join('/');
     if (ignoredTemplatePaths.has(relativePath)) continue;
     const outputPath = templateOutputPaths.get(relativePath) ?? relativePath;
-    result[outputPath] = await readFile(fullPath, 'utf8');
+    result[outputPath] = (await readFile(fullPath, 'utf8')).replace(/\r\n?/g, '\n');
   }
 
   return result;

--- a/scripts/generate-embedded-repo-skills.mjs
+++ b/scripts/generate-embedded-repo-skills.mjs
@@ -47,7 +47,7 @@ async function readDirectoryFiles(baseDir, currentDir) {
     }
     if (!entry.isFile()) continue;
     const relativePath = path.relative(baseDir, fullPath).split(path.sep).join('/');
-    result[relativePath] = await readFile(fullPath, 'utf8');
+    result[relativePath] = (await readFile(fullPath, 'utf8')).replace(/\r\n?/g, '\n');
   }
 
   return result;


### PR DESCRIPTION
## Summary

- normalize project-template text to LF before embedding
- normalize repository-skill text to LF before embedding

This makes generated TypeScript deterministic across LF and CRLF working-tree checkouts.

Fixes #48.

## Validation

- focused cross-platform check: generated both outputs from LF inputs, changed representative template and skill inputs to CRLF, regenerated, and verified identical SHA-256 hashes
- `npm run build`
- `npm run validate:skills`
- `git diff --check`
