### PR TITLE
docs(dataset): fix V2 --type examples to match CLI validation (#51)

### DIFF
--- a/scripts/run-acceptance.cjs
+++ b/scripts/run-acceptance.cjs
@@ -233,7 +233,8 @@ async function testRootHelp() {
   assert.match(stdout, /SearchCLI/);
   assert.match(stdout, /Detailed parameter constraints and request\/response contracts/);
   assert.match(stdout, /vs skill show --name vs-product-qa/);
-  assert.match(stdout, /\bitem\b/);
+  assert.match(stdout, /dataset infer-schema .*--type multi_modal --theme e_commerce/);
+  assert.doesNotMatch(stdout, /dataset infer-schema .*--type item/);
   assert.doesNotMatch(stdout, /\bproject\b/);
   assert.match(stdout, /\bllm\b/);
   assert.doesNotMatch(stdout, /\bchat-mode\b/);

--- a/src/core/root-help.ts
+++ b/src/core/root-help.ts
@@ -80,7 +80,7 @@ QUICK START
   Onboard items into a fresh app (V2 — default, backend-driven schema inference)
     vs dataset import-url --file-name items.jsonl
     curl -X PUT --data-binary "@./items.jsonl" "<FileUrl from previous step>"
-    vs dataset infer-schema --tos-key <FileKey> --type item --industry e_commerce --language zh --name <dataset-name>
+    vs dataset infer-schema --tos-key <FileKey> --type multi_modal --theme e_commerce --industry e_commerce --language zh --name <dataset-name>
     vs dataset infer-result --task-id <TaskID> --render-schema
     vs dataset create --data @dataset-create.json
     vs data write --dataset-id <DatasetId> --fields @items.json


### PR DESCRIPTION
## Summary

Fixes #51.

Recent upstream changes independently corrected most V2 dataset type examples and acceptance fixtures. This PR is now rebased onto the latest `main` and narrowed to the remaining root-help inconsistency.

## Changes

- Update the V2 quick-start `dataset infer-schema` example from rejected `--type item` to valid `--type multi_modal --theme e_commerce`.
- Replace the stale root-help `item` assertion with deterministic positive and negative assertions for the supported example.

## Verification

- `npm run validate:skills`
- `npm run build`
- `npm run test:acceptance:dist` (`54 passed, 0 failed`)
